### PR TITLE
Add removeAllNotifications function to clear notification banner

### DIFF
--- a/ios/Classes/CommnunicationNotificationPlugin.swift
+++ b/ios/Classes/CommnunicationNotificationPlugin.swift
@@ -62,13 +62,14 @@ class CommunicationNotificationPlugin {
             let identifier = "\(IosCommunicationConstant.prefixIdentifier):\(uuid):\(currentTime)"
 
             var content = UNMutableNotificationContent()
-            
+
             content.title = notificationInfo.senderName
             content.subtitle = ""
             content.body = notificationInfo.content
             content.sound = UNNotificationSound(named: UNNotificationSoundName(rawValue: "alarm"))
             content.categoryIdentifier = identifier
             content.userInfo = ["data": notificationInfo.value]
+            content.threadIdentifier = notificationInfo.threadIdentifier ?? notificationInfo.senderName
             
             var personNameComponents = PersonNameComponents()
             personNameComponents.nickname = notificationInfo.senderName

--- a/ios/Classes/CommnunicationNotificationPlugin.swift
+++ b/ios/Classes/CommnunicationNotificationPlugin.swift
@@ -136,4 +136,28 @@ class CommunicationNotificationPlugin {
             UNUserNotificationCenter.current().add(request)
         }
     }
+
+    func removeNotificationsByThread(_ threadIdentifier: String, completion: @escaping (Bool) -> Void) {
+        let notificationCenter = UNUserNotificationCenter.current()
+
+        // Get all delivered notifications
+        notificationCenter.getDeliveredNotifications { deliveredNotifications in
+            var identifiersToRemove: [String] = []
+
+            // Find all notifications with matching thread identifier
+            for deliveredNotification in deliveredNotifications {
+                if deliveredNotification.request.content.threadIdentifier == threadIdentifier {
+                    identifiersToRemove.append(deliveredNotification.request.identifier)
+                }
+            }
+
+            // Remove the notifications
+            if !identifiersToRemove.isEmpty {
+                notificationCenter.removeDeliveredNotifications(withIdentifiers: identifiersToRemove)
+                completion(true)
+            } else {
+                completion(false)
+            }
+        }
+    }
 }

--- a/ios/Classes/CommnunicationNotificationPlugin.swift
+++ b/ios/Classes/CommnunicationNotificationPlugin.swift
@@ -160,4 +160,19 @@ class CommunicationNotificationPlugin {
             }
         }
     }
+
+    func removeAllNotifications(completion: @escaping (Bool) -> Void) {
+        let notificationCenter = UNUserNotificationCenter.current()
+
+        // Get all delivered notifications to check if any exist
+        notificationCenter.getDeliveredNotifications { deliveredNotifications in
+            if !deliveredNotifications.isEmpty {
+                // Remove all delivered notifications
+                notificationCenter.removeAllDeliveredNotifications()
+                completion(true)
+            } else {
+                completion(false)
+            }
+        }
+    }
 }

--- a/ios/Classes/IosCommunicationNotificationPlugin.swift
+++ b/ios/Classes/IosCommunicationNotificationPlugin.swift
@@ -55,7 +55,8 @@ public class IosCommunicationNotificationPlugin: NSObject, FlutterPlugin {
                 return
             }
             let value = arguments["value"] as? String ?? ""
-            CommunicationNotificationPlugin().showNotification(NotificationInfo(senderName: senderName, pngImage: avatar, content: content, value: value))
+            let threadIdentifier = arguments["threadIdentifier"] as? String
+            CommunicationNotificationPlugin().showNotification(NotificationInfo(senderName: senderName, pngImage: avatar, content: content, value: value, threadIdentifier: threadIdentifier))
             result(true)
             break
         case "isAvailable":

--- a/ios/Classes/IosCommunicationNotificationPlugin.swift
+++ b/ios/Classes/IosCommunicationNotificationPlugin.swift
@@ -66,6 +66,16 @@ public class IosCommunicationNotificationPlugin: NSObject, FlutterPlugin {
                 result(false)
             }
             break
+        case "removeNotificationsByThread":
+            let arguments = call.arguments as? [String: Any] ?? [String: Any]()
+            guard let threadIdentifier = arguments["threadIdentifier"] as? String else {
+                result(false)
+                return
+            }
+            CommunicationNotificationPlugin().removeNotificationsByThread(threadIdentifier) { success in
+                result(success)
+            }
+            break
         default:
             result(FlutterMethodNotImplemented)
             break

--- a/ios/Classes/IosCommunicationNotificationPlugin.swift
+++ b/ios/Classes/IosCommunicationNotificationPlugin.swift
@@ -76,6 +76,11 @@ public class IosCommunicationNotificationPlugin: NSObject, FlutterPlugin {
                 result(success)
             }
             break
+        case "removeAllNotifications":
+            CommunicationNotificationPlugin().removeAllNotifications { success in
+                result(success)
+            }
+            break
         default:
             result(FlutterMethodNotImplemented)
             break

--- a/ios/Classes/NotificationInfo.swift
+++ b/ios/Classes/NotificationInfo.swift
@@ -5,4 +5,5 @@ struct NotificationInfo {
     var pngImage: Data
     var content: String
     var value: String
+    var threadIdentifier: String?
 }

--- a/lib/ios_communication_notification.dart
+++ b/lib/ios_communication_notification.dart
@@ -26,4 +26,8 @@ class IosCommunicationNotification {
   Future<String?> getInitialPayload() async {
     return IosCommunicationNotificationPlatform.instance.getInitialPayload();
   }
+
+  Future<bool> removeNotificationsByThread(String threadIdentifier) {
+    return IosCommunicationNotificationPlatform.instance.removeNotificationsByThread(threadIdentifier);
+  }
 }

--- a/lib/ios_communication_notification.dart
+++ b/lib/ios_communication_notification.dart
@@ -30,4 +30,8 @@ class IosCommunicationNotification {
   Future<bool> removeNotificationsByThread(String threadIdentifier) {
     return IosCommunicationNotificationPlatform.instance.removeNotificationsByThread(threadIdentifier);
   }
+
+  Future<bool> removeAllNotifications() {
+    return IosCommunicationNotificationPlatform.instance.removeAllNotifications();
+  }
 }

--- a/lib/ios_communication_notification_method_channel.dart
+++ b/lib/ios_communication_notification_method_channel.dart
@@ -46,4 +46,17 @@ class MethodChannelIosCommunicationNotification
 
     return isAvailable;
   }
+
+  @override
+  Future<bool> removeNotificationsByThread(String threadIdentifier) async {
+    if (!Platform.isIOS) return false;
+
+    final bool success = await methodChannel.invokeMethod<bool>(
+          "removeNotificationsByThread",
+          {"threadIdentifier": threadIdentifier},
+        ) ??
+        false;
+
+    return success;
+  }
 }

--- a/lib/ios_communication_notification_method_channel.dart
+++ b/lib/ios_communication_notification_method_channel.dart
@@ -59,4 +59,15 @@ class MethodChannelIosCommunicationNotification
 
     return success;
   }
+
+  @override
+  Future<bool> removeAllNotifications() async {
+    if (!Platform.isIOS) return false;
+
+    final bool success =
+        await methodChannel.invokeMethod<bool>("removeAllNotifications") ??
+            false;
+
+    return success;
+  }
 }

--- a/lib/ios_communication_notification_platform_interface.dart
+++ b/lib/ios_communication_notification_platform_interface.dart
@@ -40,4 +40,8 @@ abstract class IosCommunicationNotificationPlatform extends PlatformInterface {
   Future<String?> getInitialPayload() async {
     throw UnimplementedError('getInitialPayload() has not been implemented.');
   }
+
+  Future<bool> removeNotificationsByThread(String threadIdentifier) {
+    throw UnimplementedError('removeNotificationsByThread() has not been implemented.');
+  }
 }

--- a/lib/ios_communication_notification_platform_interface.dart
+++ b/lib/ios_communication_notification_platform_interface.dart
@@ -44,4 +44,8 @@ abstract class IosCommunicationNotificationPlatform extends PlatformInterface {
   Future<bool> removeNotificationsByThread(String threadIdentifier) {
     throw UnimplementedError('removeNotificationsByThread() has not been implemented.');
   }
+
+  Future<bool> removeAllNotifications() {
+    throw UnimplementedError('removeAllNotifications() has not been implemented.');
+  }
 }

--- a/lib/models/notification_info_model.dart
+++ b/lib/models/notification_info_model.dart
@@ -7,12 +7,14 @@ class NotificationInfo {
   final Uint8List imageBytes;
   final String content;
   final String value;
+  final String? threadIdentifier;
   final Function(String payload)? onPressed;
   NotificationInfo({
     required this.senderName,
     required this.imageBytes,
     required this.content,
     required this.value,
+    this.threadIdentifier,
     this.onPressed,
   });
 
@@ -21,6 +23,7 @@ class NotificationInfo {
     Uint8List? imageBytes,
     String? content,
     String? value,
+    String? threadIdentifier,
     Function(String payload)? onPressed,
   }) {
     return NotificationInfo(
@@ -28,6 +31,7 @@ class NotificationInfo {
       imageBytes: imageBytes ?? this.imageBytes,
       content: content ?? this.content,
       value: value ?? this.value,
+      threadIdentifier: threadIdentifier ?? this.threadIdentifier,
       onPressed: onPressed ?? this.onPressed,
     );
   }
@@ -38,6 +42,7 @@ class NotificationInfo {
       'imageBytes': imageBytes,
       'content': content,
       'value': value,
+      'threadIdentifier': threadIdentifier,
     };
   }
 
@@ -45,7 +50,7 @@ class NotificationInfo {
 
   @override
   String toString() {
-    return 'NotificationInfo(senderName: $senderName, imageBytes: $imageBytes, content: $content, value: $value, onPressed: $onPressed)';
+    return 'NotificationInfo(senderName: $senderName, imageBytes: $imageBytes, content: $content, value: $value, threadIdentifier: $threadIdentifier, onPressed: $onPressed)';
   }
 
   @override
@@ -56,6 +61,7 @@ class NotificationInfo {
         other.imageBytes == imageBytes &&
         other.content == content &&
         other.value == value &&
+        other.threadIdentifier == threadIdentifier &&
         other.onPressed == onPressed;
   }
 
@@ -65,6 +71,7 @@ class NotificationInfo {
         imageBytes.hashCode ^
         content.hashCode ^
         value.hashCode ^
+        threadIdentifier.hashCode ^
         onPressed.hashCode;
   }
 }


### PR DESCRIPTION
## Summary
Implements `removeAllNotifications()` method to provide a simple way to clear all delivered notifications from the notification banner with a single call.

This complements the existing `removeNotificationsByThread()` by allowing users to remove all notifications at once instead of having to remove them by thread identifier individually.

## Changes
- **Swift Core**: Added `removeAllNotifications(completion:)` in `CommnunicationNotificationPlugin.swift`
  - Uses iOS native `UNUserNotificationCenter.removeAllDeliveredNotifications()`
  - Returns `true` if notifications existed and were removed, `false` if none existed
- **Method Channel**: Added handler for `removeAllNotifications` in `IosCommunicationNotificationPlugin.swift`
- **Platform Interface**: Added abstract method declaration in `ios_communication_notification_platform_interface.dart`
- **Method Channel Implementation**: Implemented platform method with iOS check in `ios_communication_notification_method_channel.dart`
- **Public API**: Exposed `removeAllNotifications()` in `IosCommunicationNotification` class

## Use Case
When users want to clear all popping notifications at once, such as:
- "Clear All" button functionality
- Reset notification state on logout
- Bulk notification management

## Testing
The implementation follows the exact same pattern as the existing `removeNotificationsByThread()` method, ensuring consistency and reliability.

## Breaking Changes
None - all changes are purely additive.